### PR TITLE
Feature: cache IP addresses to reduce load on downstream systems

### DIFF
--- a/hpfeeds-bhr/feedhandler.py
+++ b/hpfeeds-bhr/feedhandler.py
@@ -11,19 +11,20 @@ import redis
 
 logging.basicConfig(level=logging.DEBUG)
 
+
 class RedisCache(object):
-    '''
+    """
     Implement a simple cache using Redis.
-    '''
-    def __init__(self):
+    """
+    def __init__(self, host='redis', port=6379, db=1):
         # This code will have implication of no more than one instance of BHR
         # In case of multiples, false cache hits will result due to db selected
-        self.r = redis.Redis(host='redis', port=6379, db=1)
+        self.r = redis.Redis(host=host, port=port, db=db)
         self.expire_t = 60
 
     def iscached(self,ip):
         a = self.r.get(ip)
-        logging.debug('Checked for {} in cache and received: {}'.format(ip,a))
+        logging.debug('Checked for {} in cache and received: {}'.format(ip, a))
         if a:
             return True
         else:
@@ -33,12 +34,13 @@ class RedisCache(object):
         a = self.r.set(name=ip, value=0, ex=self.expire_t)
         logging.debug('Sent {} to cache and received: {}'.format(ip,a))
 
+
 def parse_ignore_cidr_option(cidrlist):
-    '''
+    """
     Given a comma-seperated list of CIDR addresses, split them and validate they're valid CIDR notation
     :param cidrlist: string representing a comma seperated list of CIDR addresses
     :return: a list containing IPy.IP objects representing the ignore_cidr addresses
-    '''
+    """
     l = list()
     for c in cidrlist.split(','):
         try:
@@ -48,7 +50,6 @@ def parse_ignore_cidr_option(cidrlist):
         except ValueError as e:
             logging.warn('Received invalid CIDR in ignore_cidr: {}'.format(e))
     return l
-
 
 
 def handle_message(msg, host, token, tags, ssl, cache, include_hp_tags=False):

--- a/hpfeeds-bhr/feedhandler.py
+++ b/hpfeeds-bhr/feedhandler.py
@@ -54,7 +54,7 @@ def parse_ignore_cidr_option(cidrlist):
 def handle_message(msg, host, token, tags, ssl, cache, include_hp_tags=False):
 
     if cache.iscached(msg['src_ip']):
-        logging.debug('Skipped submitting {} due to cache hit'.format(msg['src_ip']))
+        logging.info('Skipped submitting {} due to cache hit'.format(msg['src_ip']))
         return
 
     logging.debug('Found signature: {}'.format(msg['signature']))

--- a/hpfeeds-bhr/feedhandler.py
+++ b/hpfeeds-bhr/feedhandler.py
@@ -104,6 +104,7 @@ def submit_to_bhr(data, host, token, cache):
     except (requests.exceptions.HTTPError,Exception) as e:
         if isinstance(e,requests.exceptions.HTTPError):
             logging.warn('Indicator {} is on the system safelist and was NOT blocked!'.format(data['indicator']))
+            cache.setcache(data['indicator'])
         else:
             logging.error('Error submitting indicator: {0}'.format(repr(e)))
         return False

--- a/hpfeeds-bhr/feedhandler.py
+++ b/hpfeeds-bhr/feedhandler.py
@@ -18,8 +18,8 @@ class RedisCache(object):
     def __init__(self):
         # This code will have implication of no more than one instance of BHR
         # In case of multiples, false cache hits will result due to db selected
-        r = redis.Redis(host='redis', port=6379, db=1)
-        expire_t = 60
+        self.r = redis.Redis(host='redis', port=6379, db=1)
+        self.expire_t = 60
 
     def iscached(self,ip):
         a = self.r.get(ip)

--- a/hpfeeds-bhr/feedhandler.py
+++ b/hpfeeds-bhr/feedhandler.py
@@ -23,13 +23,15 @@ class RedisCache(object):
 
     def iscached(self,ip):
         a = self.r.get(ip)
+        logging.debug('Checked for {} in cache and received: {}'.format(ip,a))
         if a:
             return True
         else:
             return False
 
     def setcache(self,ip):
-        self.r.set(name=ip, value=0, ex=self.expire_t)
+        a = self.r.set(name=ip, value=0, ex=self.expire_t)
+        logging.debug('Sent {} to cache and received: {}'.format(ip,a))
 
 def parse_ignore_cidr_option(cidrlist):
     '''

--- a/hpfeeds-bhr/processors.py
+++ b/hpfeeds-bhr/processors.py
@@ -709,6 +709,8 @@ class HpfeedsMessageProcessor(object):
         self.ignore_cidr_list=ignore_cidr_list
 
     def is_ignore_addr(self,ip):
+        if len(self.ignore_cidr_list) == 0:
+            return False
         try:
             checkip = IP(ip)
             for c in self.ignore_cidr_list:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ gevent==1.1.1
 pymongo==2.7.2
 IPy
 bhr-client
+redis


### PR DESCRIPTION
This PR includes a cache based on the included redis container. IP's are cached for 60 seconds; which ought to reduce the amount of noise seen in downstream systems (in this case BHR).

Should be easy to replicate in hpfeeds-cif and hpfeeds-output